### PR TITLE
Remove flake-utils dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,11 @@ Add the input to your flake inputs, and enable the overlay:
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/«version»";
     emacs-lsp-booster.url = "github:slotThe/emacs-lsp-booster-flake";
-    # The emacs-lsp-booster flake itself depends on `nixpkgs` and
-    # `flake-utils`; you might want to make both of these inputs
-    # follow the ones in your configuration.
+    # The emacs-lsp-booster flake itself depends on `nixpkgs`; you
+    # might want to make this input follow the one in your
+    # configuration.
     #
     # emacs-lsp-booster.inputs.nixpkgs.follows = "nixpkgs";
-    # emacs-lsp-booster.inputs.flake-utils.follows = "flake-utils";
   };
   outputs = { emacs-lsp-booster, ...}:
     let my-overlays = {

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1704194953,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,25 @@
   description = "A flake for ghub:blahgeek/emacs-lsp-booster";
 
   inputs = {
-    nixpkgs.url     = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
+  outputs = { nixpkgs, ... }:
     let overlay = final: prev: {
           emacs-lsp-booster = final.callPackage ./default.nix { };
         };
-    in {
-      overlays.default = overlay;
-    } // flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = import nixpkgs {
+        supportedSystems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" "x86_64-darwin" ];
+        forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+        nixpkgsFor = forAllSystems (system:
+          import nixpkgs {
             inherit system;
             overlays = [ overlay ];
-          };
-      in {
-        packages.default = pkgs.emacs-lsp-booster;
-      }
-    );
+          });
+    in {
+      overlays.default = overlay;
+
+      packages = forAllSystems (system: {
+        default = nixpkgsFor.${system}.emacs-lsp-booster;
+      });
+    };
 }


### PR DESCRIPTION
The flake-utils dependency isn't doing anything that can't be done with just nixpkgs. Less dependencies also means that downstream users whose tools require auditing will have have an easier time using this software.